### PR TITLE
Add computation of intercept to Linear Regression

### DIFF
--- a/notebooks/LinearRegression_Example.ipynb
+++ b/notebooks/LinearRegression_Example.ipynb
@@ -1,0 +1,364 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linear Regression\n",
+    "In this notebook, we will walk you through all the examples of linear regression models using the using the **ScikitLearn.jl** package. \n",
+    "\n",
+    "In order to successfully run these examples, it is required that you have installed both the **ScikitLearn** and the **Plots** Julia packages. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<span style=\"color:red\"><b>Note!</b></span> \n",
+    "\n",
+    "The package Plots is NOT necessary for running a Linear Regression model! In this notebook, we use it with the unique purpose of easily visualizing the approximation of Linear Regression models to the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Linear Regression Models\n",
+    "using ScikitLearn\n",
+    "\n",
+    "# Visualization\n",
+    "using Plots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Simple Linear Regression\n",
+    "A simple linear regression is a linear regression model with a single dependent variable and a single independent variable, i.e., it is a two-dimensional model where the dependent variable `y` is described by a single variable `x`.\n",
+    "\n",
+    "In the following section we see how to create a simple linear regression model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create 50 1-dimensional samples\n",
+    "X = 5 * rand(1, 50)\n",
+    "y = sin.(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that our matrix `X` has dimension `1 x n_samples` as is required by the [ScikitLearnBase API](https://scikitlearnjl.readthedocs.io/en/latest/api/). Similarly, `y` also has dimension `1 x n_samples`.\n",
+    "\n",
+    "Let's confirm that!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "println(\"size(X) == (1, 50): $(size(X) == (1, 50))\")\n",
+    "println(\"size(y) == (1, 50): $(size(y) == (1, 50))\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In real life applications, our data usually is associated with some noise. Let's add some noise to our data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Every 5 points are shifted by a random amount\n",
+    "y1[1:5:end] += 5 * (0.5 .- rand(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now it's time to create the model that we want to approximate our data with! In this case, we will use a **LinearRegression** model. Since we only have one dependent variable (`y`), we will set `multi_output=false`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create model\n",
+    "lr = ScikitLearn.Models.LinearRegression(multi_output=false)\n",
+    "\n",
+    "# Train the model\n",
+    "fit!(lr, X, y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the trained model to predict values of y\n",
+    "y_pred = predict(lr, X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Plots\n",
+    "scatter(X', y', title=\"Simple Linear Regression Model\") # Plot initial Samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot!(X', y_pred', label=\"Linear Regression\") # Plot our approximation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multi Linear Regression\n",
+    "A Multi linear regression is a linear regression model with more than one independent variable and a single dependent variable, i.e., it is an (n+1)-dimensional model where the dependent variable `y` is described by a `n` variables (`x_1, x_2, ..., x_n`).\n",
+    "In the following section we see how to create a multi-linear regression model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create 50 2-dimensional samples\n",
+    "X = rand(2, 50)\n",
+    "y = mapslices(x -> x[1] - x[2], X, dims=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that our matrix `X` now has dimension `2 x n_samples`, and that `y`'s dimension remains `1 x n_samples`. This is\n",
+    "\n",
+    "Let's confirm that!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "println(\"size(X) == (2, 50): $(size(X) == (2, 50))\")\n",
+    "println(\"size(y) == (1, 50): $(size(y) == (1, 50))\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now it's time to create the model that we want to approximate our data with! In this case, we will use a **LinearRegression** model. Since we only have one dependent variable (`y`), we will set `multi_output=false`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create model\n",
+    "lr = ScikitLearn.Models.LinearRegression(multi_output=false)\n",
+    "\n",
+    "# Train the model\n",
+    "fit!(lr, X, y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the trained model to predict values of y\n",
+    "y_pred = predict(lr, X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Plots\n",
+    "scatter(X', y', title=\"Multi Linear Regression Model\", labels=[\"Original x_1\", \"Original x_2\"]) # Plot initial Samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter!(X', y_pred', labels=[\"Linear Regression x_1\", \"Linear Regression x_2\"]) # Plot our approximation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you observe closely, the predicted points lie exactly on top of the original sampled points.\n",
+    "Now, we are going to analyse the relation of the dependent variable with the independent variable separately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x1 = X[1,:]\n",
+    "p1 = scatter(x1, y', title=\"Linear Regression X_1\")\n",
+    "scatter!(p1, x1, y_pred')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x2 = X[2, :]\n",
+    "p2 = scatter(x2, y', title=\"Linear Regression X_2\")\n",
+    "plot!(p2, x2, y_pred')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = plot(p1, p2, layout=(2, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multi-Target Regression\n",
+    "A Multi target regression is a linear regression model with at least one independent variable and more than one dependent variable, i.e., it is an (n+m)-dimensional model with `m` dependent variables (`y_1, y_2, ..., y_n`) being described by some functions of `n` variables (`x_1, x_2, ..., x_n`).\n",
+    "In the following section we see how to create a multi-target regression model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create 5 1-dimensional samples\n",
+    "X = [1 2 3 4 5]\n",
+    "y = [1  2  3  4  5;\n",
+    "    -1 -2 -3 -4 -5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "println(\"size(X) == (1, 5): $(size(X) == (1, 5))\")\n",
+    "println(\"size(y) == (2, 5): $(size(y) == (2, 5))\") # We now have two targets, i.e., two dependent variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create model\n",
+    "lr = ScikitLearn.Models.LinearRegression(multi_output=true) # Now we have a multi_output problem!!\n",
+    "\n",
+    "# Train the model\n",
+    "fit!(lr, X, y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the trained model to predict values of y\n",
+    "y_pred = predict(lr, X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, because we did not add any noise and because the dependent variables are **linear functions** of the independent variable `x`, we expect the predict y to be very close to the original `Y` variables. To confirm this we will define a `close-enough` method that determines whether a given value `x0` is close enough of the value `x1` for a given tolerance (`tol`). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "close_enough(x0, x1) = close_enough(x0, x1, tol=1e-14) = abs(x0 - x1) <= tol ? true : false"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To validate our initial idea that y_pred will be approximately equal to y, we expect the result of mapping the function close_enough to all elements of t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all(map(close_enough, y_pred, y)) "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.0.0",
+   "language": "julia",
+   "name": "julia-1.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/models/linear_regression.jl
+++ b/src/models/linear_regression.jl
@@ -14,10 +14,10 @@ Optimized for speed.
 - `eltype`: the element type of the coefficient array. `Float64` is generally
 best for numerical reasons.
 - `multi_output`: for maximum efficiency, specify `multi_output=true/false` """
-function LinearRegression(; eltype=Float64, multi_output=nothing)
+function LinearRegression(; eltype=Float64, multi_output::Union{Nothing, Bool}=nothing)
     if multi_output === nothing
         LinearRegression{Array{eltype}, eltype}()
-    elseif multi_output::Bool != nothing
+    else
         LinearRegression{Array{eltype, 2}, eltype}()
     end
 end
@@ -29,9 +29,10 @@ function ScikitLearnBase.fit!(lr::LinearRegression, X::AbstractArray{XT},
     if XT == Float32 || yT == Float32
         warn("Regression on Float32 is prone to inaccuracy")
     end
-    results = [ones(size(X, 2), 1) X'] \ y
+    results = [ones(size(X, 2), 1) X'] \ y'
     lr.intercepts = results[1,:];
     lr.coefs = results[2:end,:];
+    lr
 end
 
 ScikitLearnBase.predict(lr::LinearRegression, X) = lr.coefs' * X .+ lr.intercepts

--- a/src/models/linear_regression.jl
+++ b/src/models/linear_regression.jl
@@ -1,9 +1,9 @@
 using Compat: @compat
 
-mutable struct LinearRegression{T <: Array} <: BaseRegressor
+mutable struct LinearRegression{T<:Array,Y<:Number} <: BaseRegressor
     coefs::T
-    intercept::Real
-    LinearRegression{T}() where T = new{T}()
+    intercepts::Array{Y, 1}
+    LinearRegression{T,Y}() where{T,Y} = new{T, Y}()
 end
 
 """    LinearRegression(; eltype=Float64, multi_output=nothing)
@@ -16,11 +16,9 @@ best for numerical reasons.
 - `multi_output`: for maximum efficiency, specify `multi_output=true/false` """
 function LinearRegression(; eltype=Float64, multi_output=nothing)
     if multi_output === nothing
-        LinearRegression{Array{eltype}}()
-    elseif multi_output::Bool
-        LinearRegression{Array{eltype, 2}}()
-    else
-        LinearRegression{Array{eltype, 1}}()
+        LinearRegression{Array{eltype}, eltype}()
+    elseif multi_output::Bool != nothing
+        LinearRegression{Array{eltype, 2}, eltype}()
     end
 end
 
@@ -32,8 +30,8 @@ function ScikitLearnBase.fit!(lr::LinearRegression, X::AbstractArray{XT},
         warn("Regression on Float32 is prone to inaccuracy")
     end
     results = [ones(size(X, 2), 1) X'] \ y
-    lr.intercept = results[1];
-    lr.coefs = results[2:end];
+    lr.intercepts = results[1,:];
+    lr.coefs = results[2:end,:];
 end
 
-ScikitLearnBase.predict(lr::LinearRegression, X) = lr.coefs' * X .+ lr.intercept
+ScikitLearnBase.predict(lr::LinearRegression, X) = lr.coefs' * X .+ lr.intercepts

--- a/test/test_linearRegression.jl
+++ b/test/test_linearRegression.jl
@@ -1,5 +1,6 @@
 module TestingLinearRegression
 
+using Test
 using ScikitLearn.Models: LinearRegression
 
 close_enough(x0, x1, tol=1e-14) = abs(x0 - x1) <= tol ? true : false

--- a/test/test_linearRegression.jl
+++ b/test/test_linearRegression.jl
@@ -1,7 +1,7 @@
 module TestingLinearRegression
 
 using Test
-using ScikitLearn.Models: LinearRegression
+using ScikitLearn.Models: LinearRegression, fit!, predict
 
 close_enough(x0, x1, tol=1e-14) = abs(x0 - x1) <= tol ? true : false
 

--- a/test/test_linearRegression.jl
+++ b/test/test_linearRegression.jl
@@ -1,0 +1,72 @@
+module TestingLinearRegression
+
+using ScikitLearn.Model: LinearRegression
+
+close_enough(x0, x1, tol=1e-14) = abs(x0 - x1) <= tol ? true : false
+
+@testset "Single-Target Keyword Tests" begin
+
+    @testset "One-independent variable Tests" begin
+        # Matrices should be n_features x n_samples
+        X = [1 2 3 4 5]
+        y = identity.(X)
+
+        @test begin
+            y_pred = predict(fit!(LinearRegression(), X, y), X)
+            all(map(close_enough, y_pred, y))
+        end
+        @test begin
+            y_pred = predict(fit!(LinearRegression(multi_output=false), X, y), X)
+            all(map(close_enough, y_pred, y))
+        end
+    end
+
+    @testset "Two-independent variables Tests" begin
+         X = [1 2 3 4 5 ;
+              2 4 6 8 10]
+         y = mapslices(x -> x[1] - x[2], X, dims=1)
+
+         @test begin
+             y_pred = predict(fit!(LinearRegression(), X, y), X)
+             all(map(close_enough, y_pred, y))
+         end
+         @test begin
+             y_pred = predict(fit!(LinearRegression(multi_output=false), X, y), X)
+             all(map(close_enough, y_pred, y))
+         end
+    end
+end
+
+@testset "Multi-Target Keyword Tests" begin
+    # Matrices should be n_features x n_samples
+    @testset "One-independent variable Tests" begin
+        X = [1 2 3 4 5]
+        y = [1  2  3  4  5;
+            -1 -2 -3 -4 -5]
+        @test begin
+            y_pred = predict(fit!(LinearRegression(), X, y), X)
+            all(map(close_enough, y_pred, y))
+        end
+        @test begin
+            y_pred = predict(fit!(LinearRegression(multi_output=true), X, y), X)
+            all(map(close_enough, y_pred, y))
+        end
+    end
+
+    @testset "Two-independent variable Tests" begin
+        X = [1 2 3 4 5 ;
+             2 4 6 8 10]
+        y = mapslices(x -> [x[1] + x[2], x[1] - x[2]], X, dims=1)
+
+        @test begin
+            y_pred = predict(fit!(LinearRegression(), X, y), X)
+            all(map(close_enough, y_pred, y))
+        end
+        @test begin
+            y_pred = predict(fit!(LinearRegression(multi_output=true), X, y), X)
+            all(map(close_enough, y_pred, y))
+        end
+    end
+end
+
+end # module

--- a/test/test_linearRegression.jl
+++ b/test/test_linearRegression.jl
@@ -1,6 +1,6 @@
 module TestingLinearRegression
 
-using ScikitLearn.Model: LinearRegression
+using ScikitLearn.Models: LinearRegression
 
 close_enough(x0, x1, tol=1e-14) = abs(x0 - x1) <= tol ? true : false
 

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -2,3 +2,7 @@ using ScikitLearn
 using Test
 
 @test predict(fit!(clone(ScikitLearn.Models.FixedFunctionRegressor(predict_fn=sum)), Matrix(1.0I, 10, 10), [1,2,3]), ones(5, 2)) == [2.0, 2.0, 2.0, 2.0, 2.0]
+
+@testset "LinearRegression Tests" begin
+    include("test_linearRegression.jl")
+end


### PR DESCRIPTION
Fixed Syntax
- Fixed miss-spell of parameter multi_output.
- Updated the methods type to be **AbstractArray**, thus it can receive a transposed matrix, which is not of type Array but is of type AbstractArray. 

Add Functionality
- Intercept computation 
