### PR TITLE
Complied to a deprecation warning.

### DIFF
--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -155,7 +155,7 @@ macro sk_import(expr)
         # module at macro-expansion-time, which happens before Skcore.import_sklearn().
         # The new `pyimport`-based implementation is cleaner - Mar'17
         mod_obj = pyimport($mod_string)
-        $([:(const $(esc(w)) = mod_obj.$(w))
+        $(.(const $(esc(w)) = mod_obj.$(w))
            for w in members]...)
     end)
 end


### PR DESCRIPTION
julia> @sk_import linear_model: LinearRegression
┌ Warning: `getindex(o::PyObject, s::Symbol)` is deprecated in favor of dot overloading (`getproperty`) so elements should now be accessed as e.g. `o.s` instead of `o[:s]`.
│   caller = import_sklearn() at Skcore.jl:120