### PR TITLE
use VersionParsing for Python version numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ScikitLearnBase = "6e75b9c4-186b-50bd-896f-2d2496a4843e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
 DataFrames = "0.20,0.21"
@@ -42,6 +43,7 @@ NBInclude = "2.1"
 PyPlot = "2.8"
 RData = "0.7"
 RDatasets = "0.6"
+VersionParsing = "1"
 
 [extras]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -31,7 +31,7 @@ function importpy(name::AbstractString)
         end
     end
 end
-        
+
 
 # These definitions are potentially costly. Get rid of the pywrap?
 sklearn() = importpy("sklearn")
@@ -113,23 +113,16 @@ symbols_in(e::Expr) = union(symbols_in(e.head), map(symbols_in, e.args)...)
 symbols_in(e::Symbol) = Set([e])
 symbols_in(::Any) = Set()
 
+import VersionParsing
+
 import_already_warned = false
 function import_sklearn()
     global import_already_warned
     mod = PyCall.pyimport_conda("sklearn", "scikit-learn")
-    
-    version_ = if occursin(r"^\d+\.\d+\.\d+$", mod.__version__) #matches strings of form resembling 0.21.2 
-        mod.__version__
-    else
-        #since match above failed it assumes that the string must be of the form resembling 0.21.2.post1
-        #It then splits the string an extracts a string of the form 0.21.2 which is a legal version number
-        # version resembling 0.21.2 are similar to 0.21.2.post1 which adds bugs fixes to the release
-        rsplit(mod.__version__, ".", limit = 2)[1]
-    end     
-   version = VersionNumber(version_)
-       
-   min_version = v"0.18.0"
-   if version < min_version && !import_already_warned
+
+    version = VersionParsing.vparse(mod.__version__)
+    min_version = v"0.18.0"
+    if version < min_version && !import_already_warned
         @warn("Your Python's scikit-learn has version $version. We recommend updating to $min_version or higher for best compatibility with ScikitLearn.jl.")
         import_already_warned = true
     end


### PR DESCRIPTION
Fixes #67.

For example:
```
julia> vparse("0.21.2.post1")
v"0.21.2+post1"
```