### PR TITLE
Fix docs CI

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GaussianMixtures = "cc18c42c-b769-54ff-9e2a-b28141a64aae"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,13 @@
+using Conda
+if Base.VERSION <= v"1.6.2" 
+	# GLIBCXX_3.4.26 
+	Conda.add("libstdcxx-ng>=3.4,<9.2", channel="conda-forge")
+else 
+	# GLIBCXX_3.4.29 
+	# checked up to v1.8.0 
+	Conda.add("libstdcxx-ng>=3.4,<11.4", channel="conda-forge")
+end 
+
 using Pkg
 using Documenter
 using ScikitLearn


### PR DESCRIPTION
Adding the `libstdcxx-ng` patch seems to also fix the docs. Quite a few doctests appear to fail, but the docs should still be good. 