### PR TITLE
loosen bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   PYTHON: Conda 
-  LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$HOME/.julia/conda/3/lib
+  LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$HOME/.julia/conda/3/x86_64/lib
   
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: julia-actions/cache@v1 # https://github.com/julia-actions/cache
       - uses: julia-actions/julia-buildpkg@latest
       - name: "Install Conda"
-        if: $${{runner.os == 'Linux' && matrix.version == '1.6'}}
+        if: ${{runner.os == 'Linux' && matrix.version == '1.6'}}
         run: |
               julia -e 'using Pkg; Pkg.add("Conda");'
               cd $LD_LIBRARY_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   PYTHON: Conda 
-  LD_LIBRARY_PATH: /home/runner/.julia/conda/3/x86_64/lib
+  LD_PRELOAD: /home/runner/.julia/conda/3/x86_64/lib # used by linux os only
   
 jobs:
   test:
@@ -40,7 +40,7 @@ jobs:
         if: ${{runner.os == 'Linux' && matrix.version == '1.6'}}
         run: |
               julia -e 'using Pkg; Pkg.add("Conda");'
-              cd $LD_LIBRARY_PATH
+              export  LD_PRELOAD = $LD_PRELOAD
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,10 @@ jobs:
       - uses: julia-actions/cache@v1 # https://github.com/julia-actions/cache
       - uses: julia-actions/julia-buildpkg@latest
       - name: "Install Conda"
+        if: $${{runner.os == 'Linux' && matrix.version == '1.6'}}
         run: |
               julia -e 'using Pkg; Pkg.add("Conda");'
               cd $LD_LIBRARY_PATH
-          if: runner.os == 'Linux' && matrix.version == '1.6'
-          
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "1.6"
+          - "1.7"
           - "1"
           - "nightly"
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
               julia -e 'using Pkg; Pkg.add("Conda");'
               cd $LD_LIBRARY_PATH
           if: runner.os == 'Linux' && matrix.version == '1.6'
+          
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,9 @@ jobs:
           arch: ${{ matrix.julia-arch }}
       - uses: julia-actions/cache@v1 # https://github.com/julia-actions/cache
       - uses: julia-actions/julia-buildpkg@latest
-      - name: "Install Conda"
+      - name: "Export LD_LIBRARY_PATH envrioment variable"
         if: ${{matrix.os == 'ubuntu-latest' && matrix.julia-version == '1.6'}}
-        run: |
-              julia -e 'using Pkg; Pkg.add("Conda");'
-              export LD_PRELOAD=$LD_LIBRARY_PATH
+        run: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   PYTHON: Conda 
-  LD_PRELOAD: /home/runner/.julia/conda/3/x86_64/lib # used by linux os only
+  LD_LIBRARY_PATH: /home/runner/.julia/conda/3/x86_64/lib # used by linux os only
   
 jobs:
   test:
@@ -37,10 +37,10 @@ jobs:
       - uses: julia-actions/cache@v1 # https://github.com/julia-actions/cache
       - uses: julia-actions/julia-buildpkg@latest
       - name: "Install Conda"
-        if: ${{runner.os == 'Linux' && matrix.version == '1.6'}}
+        if: ${{matrix.os == 'ubuntu-latest' && matrix.julia-version == '1.6'}}
         run: |
               julia -e 'using Pkg; Pkg.add("Conda");'
-              export  LD_PRELOAD = $LD_PRELOAD
+              export  LD_LIBRARY_PATH = $LD_LIBRARY_PATH
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,9 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - name: "Install Conda"
         run: |
-              if ["$RUNNER_OS" == "Linux"]; then
-                  julia -e 'using Pkg; Pkg.add("Conda");'
-                  cd $LD_LIBRARY_PATH
-              fi
+              julia -e 'using Pkg; Pkg.add("Conda");'
+              cd $LD_LIBRARY_PATH
+          if: runner.os == 'Linux' && matrix.version == '1.6'
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         if: ${{matrix.os == 'ubuntu-latest' && matrix.julia-version == '1.6'}}
         run: |
               julia -e 'using Pkg; Pkg.add("Conda");'
-              export  LD_LIBRARY_PATH = $LD_LIBRARY_PATH
+              export LD_PRELOAD=$LD_LIBRARY_PATH
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   PYTHON: Conda 
-  LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$HOME/.julia/conda/3/x86_64/lib
+  LD_LIBRARY_PATH: /home/runner/.julia/conda/3/x86_64/lib
   
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "1.7"
+          - "1.6"
           - "1"
           - "nightly"
         os:
@@ -36,6 +36,12 @@ jobs:
           arch: ${{ matrix.julia-arch }}
       - uses: julia-actions/cache@v1 # https://github.com/julia-actions/cache
       - uses: julia-actions/julia-buildpkg@latest
+      - name: "Install Conda"
+        run: |
+              if ["$RUNNER_OS" == "Linux"]; then
+                  julia -e 'using Pkg; Pkg.add("Conda");'
+                  cd $LD_LIBRARY_PATH
+              fi
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1
         continue-on-error: true

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
 Compat = "2.2, 3, 4"
-Conda = "1.5.2, 1.6, 1.7"
+Conda = "1.8"
 DataFrames = "0.20, 0.21, 0.22, 1"
 IterTools = "1.2, 1.3"
 MacroTools = "0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ PyCall = "1.92, 1.93, 1.94"
 ScikitLearnBase = "0.5"
 StatsBase = "0.33"
 VersionParsing = "1.2"
-julia = "1.6"
+julia = "1.7"
 
 [extras]
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ PyCall = "1.92, 1.93, 1.94"
 ScikitLearnBase = "0.5"
 StatsBase = "0.33"
 VersionParsing = "1.2"
-julia = "1.7"
+julia = "1.6"
 
 [extras]
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ To install ScikitLearn.jl, type `]add ScikitLearn` at the REPL.
 
 To import Python models (optional), ScikitLearn.jl requires [the scikit-learn Python library](https://cstjean.github.io/ScikitLearn.jl/dev/man/models/#Installation-and-importing-Python-models-1), which will be installed automatically when needed. Most of the examples use [PyPlot.jl](https://github.com/stevengj/PyPlot.jl)
 
+## Known issue
+
+On Linux builds, importing python models via `@sk_import` is known to fail for Julia v<0.8.4 when the `PYTHON` enviroment variable from `PyCall.jl` is set to `""` or `conda`. This is becuase the version libstdcxx loaded by Julia v<0.8.4 isn't compatible with the version of scikit-learn installed via Conda.
+The easiest and recommended way to resolve this is to upgrade to Julia v>=1.8.4. If you must stick with your current julia version you can also resolve this issue by pre-appending your system's `LD_LIBRARY_PATH` enviroment variable as shown below
+```bash
+ROOT_ENV=`julia -e "using Conda; print(Conda.ROOTENV)`
+export LD_LIBRARY_PATH=$ROOT_ENV"/lib":$LD_LIBRARY_PATH
+```
+
 ## Documentation
 
 See the [manual](https://cstjean.github.io/ScikitLearn.jl/dev/) and

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -173,26 +173,25 @@ function import_sklearn()
                     # check for existence of mkl-service. 
                     # Numpy, sklearn, etc. requires either `mkl` or `no-mkl` service to run
                     # By default Conda comes with mkl
-                    # For this package to run on MacOS the `no-mkl` versions of Numpy, sklearn is needed   
-                    pyimport("mkl")
+                    # For this package to run on MacOS, the `no-mkl` versions of Numpy, sklearn are needed   
+                    pyimport("mkl") # goes to catch block if "mkl" doesn't exist on the users Mac
                     
-                    #following Code runs only if mkl-service exists otherwise jumps to catch branch
+                    # following Code runs only if mkl-service exists otherwise jumps to catch branch
                     @info "Installing non-mkl versions of sci-kit learn via Conda"
-                    #use non-mkl versions of python packages when ENV["PYTHON"]="Conda" or "" is used
-                    #when a different non-conda local python is used everthing works fine
+                    # Use non-mkl versions of python packages when ENV["PYTHON"]="Conda" or "" is used
+                    # When a different non-conda local python is used everthing works fine
                     Conda.add("nomkl")
                     Conda.rm("mkl")#This also removes mkl-service
-                    #force reinstall of scikit-learn replacing any previous mkl version
-                    Conda.add("scikit-learn<=1.2", channel="conda-forge")
-                    Conda.add("openblas")
-                    Conda.add("llvm-openmp", channel = "conda-forge")
-                    mkl_checked = true
-                catch
-                    mkl_checked = true
-                end   
+                catch err
+                    ## This block is reached when `mkl` pkg isn't installed.
+                end
+                # force reinstall of scikit-learn replacing any previous mkl version
+                Conda.add("scikit-learn<=1.2", channel="conda-forge")
+                #Conda.add("openblas")
+                #Conda.add("llvm-openmp", channel = "conda-forge")
+                mkl_checked = true
             end
-            Conda.add("llvm-openmp", channel = "conda-forge")
-            PyCall.pyimport_conda("sklearn", "scikit-learn")
+            PyCall.pyimport_conda("sklearn", "scikit-learn<=1.2", "conda-forge")
         
         catch
             @info("scikit-learn isn't properly installed."*

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -199,21 +199,18 @@ function import_sklearn()
             rethrow()
         end
 
-    elseif Sys.islinux()
-        if !libstdcxx_solved
+    else 
+        if Sys.islinux() && !libstdcxx_solved
             version = _compatible_libstdcxx_ng_version()
             Conda.add("conda", channel="anaconda")
             Conda.add("libstdcxx-ng$version", channel="conda-forge")
-            if version == ">=3.4,<12.0" 
-                # https://github.com/scikit-learn/scikit-learn/pull/23990
-                Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge") 
-            end
+            #if version == ">=3.4,<12.0" 
+            #    # https://github.com/scikit-learn/scikit-learn/pull/23990
+            #    Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge") 
+            #end
             libstdcxx_solved = true
         end
-
-        mod = PyCall.pyimport_conda("sklearn", "scikit-learn")
-    else
-        mod = PyCall.pyimport_conda("sklearn", "scikit-learn")
+        mod = PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")
     end
 
    version = VersionParsing.vparse(mod.__version__)

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -200,14 +200,15 @@ function import_sklearn()
         end
 
     else 
-        if Sys.islinux() && !libstdcxx_solved
+        @static if Sys.islinux() && !libstdcxx_solved
             version = _compatible_libstdcxx_ng_version()
-            #Conda.add("conda", channel="anaconda")
+            Conda.add("conda", channel="anaconda")
             Conda.add("libstdcxx-ng$version", channel="conda-forge")
             #if version == ">=3.4,<12.0" 
             #    # https://github.com/scikit-learn/scikit-learn/pull/23990
             #    Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge") 
             #end
+            Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge")
             libstdcxx_solved = true
         end
         mod = PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -200,17 +200,18 @@ function import_sklearn()
         end
 
     else 
+        #=
         @static if Sys.islinux() && !libstdcxx_solved
             version = _compatible_libstdcxx_ng_version()
             Conda.add("conda", channel="anaconda")
             Conda.add("libstdcxx-ng$version", channel="conda-forge")
-            #if version == ">=3.4,<12.0" 
-            #    # https://github.com/scikit-learn/scikit-learn/pull/23990
-            #    Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge") 
-            #end
-            Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge")
+            if version == ">=3.4,<12.0" 
+                # https://github.com/scikit-learn/scikit-learn/pull/23990
+                Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge") 
+            end
             libstdcxx_solved = true
         end
+        =#
         mod = PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")
     end
 

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -186,12 +186,12 @@ function import_sklearn()
                     ## This block is reached when `mkl` pkg isn't installed.
                 end
                 # force reinstall of scikit-learn replacing any previous mkl version
-                Conda.add("scikit-learn<=1.2", channel="conda-forge")
+                Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge")
                 #Conda.add("openblas")
                 #Conda.add("llvm-openmp", channel = "conda-forge")
                 mkl_checked = true
             end
-            PyCall.pyimport_conda("sklearn", "scikit-learn<=1.2", "conda-forge")
+            PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")
         
         catch
             @info("scikit-learn isn't properly installed."*
@@ -206,7 +206,7 @@ function import_sklearn()
             Conda.add("libstdcxx-ng$version", channel="conda-forge")
             if version == ">=3.4,<12.0" 
                 # https://github.com/scikit-learn/scikit-learn/pull/23990
-                Conda.add("scikit-learn<=1.2", channel="conda-forge") 
+                Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge") 
             end
             libstdcxx_solved = true
         end

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -211,11 +211,18 @@ function import_sklearn()
         PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")
     catch
         INFO_MSG = "scikit-learn isn't properly installed."*
-        "Please use PyCall default Conda or non-conda local python."
+        "Please make sure PyCall is using the default Conda or non-conda local python."
         @static if Sys.islinux()
-            INFO_MSG = INFO_MSG * 
-                "\n libstdcxx is a known issue on earlier versions on Julia." *
-                "Please consider upgrading to Julia v>=1.8.4."
+            if libstdcxx_solved
+                INFO_MSG = INFO_MSG * 
+                    "\nIf you are experiencing Conda package conflicts, this may "*
+                    "be because the version libstdcxx loaded by Julia $(Base.VERSION) "*
+                    "isn't compatible with the version of scikit-learn installed by "*
+                    "Conda. To resolve this, we recommend upgrading to Julia v>=1.8.4.\n"*
+                    "If you must stick with your current julia version you can "*
+                    "also resolve this issue by pre-appending `$(CONDA.ROOTENV)/lib` to "*
+                    "your system's `LD_LIBRARY_PATH` enviroment variable."
+            end
         end
         @info(INFO_MSG)
         rethrow()

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -212,6 +212,7 @@ function import_sklearn()
             end
             =#
             libstdcxx_solved = true
+            
         end
 
         mod = PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -174,21 +174,30 @@ function import_sklearn()
                     # Numpy, sklearn, etc. requires either `mkl` or `no-mkl` service to run
                     # By default Conda comes with mkl
                     # For this package to run on MacOS, the `no-mkl` versions of Numpy, sklearn are needed   
-                    pyimport("mkl") # jumps to the finally block if "mkl" doesn't exist on the users Mac
+                    pyimport("mkl") # jumps to catch block if "mkl" doesn't exist on the users Mac
                     
-                    # following Code runs only if mkl-service exists otherwise jumps to finally branch
-                    @info "Installing non-mkl versions of sci-kit learn via Conda"
-                    # Use non-mkl versions of python packages when ENV["PYTHON"]="Conda" or "" is used
+                    # following Code runs only if mkl-service exists otherwise jumps to catch branch
+                    @info(
+                        "Uninstalling mkl and Installing "*
+                        "non-mkl versions of sci-kit learn via Conda"
+                    )
+                    # Use non-mkl versions of python packages when ENV["PYTHON"]="Conda" 
+                    # or "" is used.
                     # When a different non-conda local python is used everthing works fine
                     Conda.add("nomkl")
                     Conda.rm("mkl")#This also removes mkl-service
-                finally
-                    # force reinstall of scikit-learn replacing any previous mkl version
-                    Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge")
-                    #Conda.add("openblas")
-                    #Conda.add("llvm-openmp", channel = "conda-forge")
-                    mkl_checked = true
+                catch err
+                    ## This block is reached when `mkl` pkg isn't installed.
+                    @info(
+                        "mkl not found, proceeding to installing non-mkl versions "*
+                        "of sci-kit learn via Conda"
+                    )
                 end
+                # force reinstall of scikit-learn replacing any previous mkl version
+                Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge")
+                #Conda.add("openblas")
+                #Conda.add("llvm-openmp", channel = "conda-forge")
+                mkl_checked = true
             end
             #PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")
         else

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -202,7 +202,7 @@ function import_sklearn()
     else 
         if Sys.islinux() && !libstdcxx_solved
             version = _compatible_libstdcxx_ng_version()
-            Conda.add("conda", channel="anaconda")
+            #Conda.add("conda", channel="anaconda")
             Conda.add("libstdcxx-ng$version", channel="conda-forge")
             #if version == ">=3.4,<12.0" 
             #    # https://github.com/scikit-learn/scikit-learn/pull/23990

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -193,7 +193,8 @@ function import_sklearn()
             end
             #PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")
         else
-            @static if Sys.islinux() && !libstdcxx_solved
+            @static if Sys.islinux()
+                if !libstdcxx_solved
                 version = _compatible_libstdcxx_ng_version()
                 Conda.add("conda", channel="anaconda")
                 Conda.add("libstdcxx-ng$version", channel="conda-forge")
@@ -204,6 +205,7 @@ function import_sklearn()
                 end
                 =#
                 libstdcxx_solved = true
+                end
             end
         end
         PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -183,7 +183,7 @@ function import_sklearn()
                     Conda.add("nomkl")
                     Conda.rm("mkl")#This also removes mkl-service
                     #force reinstall of scikit-learn replacing any previous mkl version
-                    Conda.add("scikit-learn")
+                    Conda.add("scikit-learn<=1.2", channel="conda-forge")
                     Conda.add("openblas")
                     Conda.add("llvm-openmp", channel = "conda-forge")
                     mkl_checked = true
@@ -207,7 +207,7 @@ function import_sklearn()
             Conda.add("libstdcxx-ng$version", channel="conda-forge")
             if version == ">=3.4,<12.0" 
                 # https://github.com/scikit-learn/scikit-learn/pull/23990
-                Conda.add("scikit-learn<1.1", channel="conda-forge") 
+                Conda.add("scikit-learn<=1.2", channel="conda-forge") 
             end
             libstdcxx_solved = true
         end

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -174,22 +174,21 @@ function import_sklearn()
                     # Numpy, sklearn, etc. requires either `mkl` or `no-mkl` service to run
                     # By default Conda comes with mkl
                     # For this package to run on MacOS, the `no-mkl` versions of Numpy, sklearn are needed   
-                    pyimport("mkl") # goes to catch block if "mkl" doesn't exist on the users Mac
+                    pyimport("mkl") # jumps to the finally block if "mkl" doesn't exist on the users Mac
                     
-                    # following Code runs only if mkl-service exists otherwise jumps to catch branch
+                    # following Code runs only if mkl-service exists otherwise jumps to finally branch
                     @info "Installing non-mkl versions of sci-kit learn via Conda"
                     # Use non-mkl versions of python packages when ENV["PYTHON"]="Conda" or "" is used
                     # When a different non-conda local python is used everthing works fine
                     Conda.add("nomkl")
                     Conda.rm("mkl")#This also removes mkl-service
-                catch err
-                    ## This block is reached when `mkl` pkg isn't installed.
+                finally
+                    # force reinstall of scikit-learn replacing any previous mkl version
+                    Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge")
+                    #Conda.add("openblas")
+                    #Conda.add("llvm-openmp", channel = "conda-forge")
+                    mkl_checked = true
                 end
-                # force reinstall of scikit-learn replacing any previous mkl version
-                Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge")
-                #Conda.add("openblas")
-                #Conda.add("llvm-openmp", channel = "conda-forge")
-                mkl_checked = true
             end
             #PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")
         else

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -200,18 +200,20 @@ function import_sklearn()
         end
 
     else 
-        #=
+        
         @static if Sys.islinux() && !libstdcxx_solved
             version = _compatible_libstdcxx_ng_version()
             Conda.add("conda", channel="anaconda")
             Conda.add("libstdcxx-ng$version", channel="conda-forge")
+            #=
             if version == ">=3.4,<12.0" 
                 # https://github.com/scikit-learn/scikit-learn/pull/23990
                 Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge") 
             end
+            =#
             libstdcxx_solved = true
         end
-        =#
+
         mod = PyCall.pyimport_conda("sklearn", "scikit-learn>=1.2,<1.3", "conda-forge")
     end
 


### PR DESCRIPTION
At the moment, `ScikitLearn.jl` limits the conda sklearn version to <1.1 for Linux users. This was due to the libstdxx issue with Julia, which has long been fixed for later Julia versions `>=v0.8.4`. 
This PR proposes loosens the bounds of the conda sklearn version. It also makes sure that compatible conda sklearn versions are installed across Windows, macOS, and linux platforms. At the moment this corresponds to version `>=1.2, <1.3` (This was chosen, since a minor release may contain several code deprecations). We could change this bound when python sklearn releases a new minor release, which doesn't happen often.

cc. @cstjean, @tylerjthomas9 @ablaom