### PR TITLE
Avoid trying to install `libstdcxx-ngnothing`

### DIFF
--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -203,12 +203,12 @@ function import_sklearn()
         else
             @static if Sys.islinux()
                 if !libstdcxx_solved
-                version = _compatible_libstdcxx_ng_version()
-                if version !== nothing
-                    Conda.add("conda", channel="anaconda")
-                    Conda.add("libstdcxx-ng$version", channel="conda-forge")
-                end
-                libstdcxx_solved = true
+                    version = _compatible_libstdcxx_ng_version()
+                    if version !== nothing
+                        Conda.add("conda", channel="anaconda")
+                        Conda.add("libstdcxx-ng$version", channel="conda-forge")
+                    end
+                    libstdcxx_solved = true
                 end
             end
         end

--- a/src/Skcore.jl
+++ b/src/Skcore.jl
@@ -204,14 +204,10 @@ function import_sklearn()
             @static if Sys.islinux()
                 if !libstdcxx_solved
                 version = _compatible_libstdcxx_ng_version()
-                Conda.add("conda", channel="anaconda")
-                Conda.add("libstdcxx-ng$version", channel="conda-forge")
-                #=
-                if version == ">=3.4,<12.0" 
-                    # https://github.com/scikit-learn/scikit-learn/pull/23990
-                    Conda.add("scikit-learn>=1.2,<1.3", channel="conda-forge") 
+                if version !== nothing
+                    Conda.add("conda", channel="anaconda")
+                    Conda.add("libstdcxx-ng$version", channel="conda-forge")
                 end
-                =#
                 libstdcxx_solved = true
                 end
             end


### PR DESCRIPTION
Ref https://github.com/cstjean/ScikitLearn.jl/issues/125

When libstdcxx is not one of the compatible versions, avoid trying to install `libstdcxx-ngnothing`.  This will cause the user to have to make sure the library is compatible if their libstdcxx version is not in the mapping. I think eventually we can remove this mapping, but the current LTS version of Julia doesn't work with recent scikit-learn versions, so it should hopefully solve any headaches from this. 